### PR TITLE
lmpack.c: rework of compat-defines (fixes #9)

### DIFF
--- a/lmpack.c
+++ b/lmpack.c
@@ -15,12 +15,13 @@
  * compilation.
  */
 #define LUA_LIB
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
 
-#include <lua.h>
 #include <lauxlib.h>
+#include <lua.h>
+#include <luaconf.h>
 
 #ifdef MPACK_USE_AMALGAMATION
 # define MPACK_API static
@@ -34,15 +35,19 @@
 #define SESSION_META_NAME "mpack.Session"
 #define NIL_NAME "mpack.NIL"
 
-#if LUA_VERSION_NUM > 501
 /* 
  * TODO(tarruda): When targeting lua 5.3 and being compiled with `long long`
  * support(not -ansi), we should make use of lua 64 bit integers for
  * representing msgpack integers, since `double` can't represent the full range.
  */
-typedef luaL_Reg luaL_reg;
-#define luaL_register(L, name, lreg) (luaL_setfuncs((L), (lreg), 0))
-#define lua_objlen(L, idx) (lua_rawlen(L, (idx)))
+
+#ifndef luaL_reg
+/* Taken from Lua5.1's lauxlib.h */
+#define luaL_reg    luaL_Reg
+#endif
+
+#if LUA_VERSION_NUM > 501
+#define luaL_register(L,n,f) luaL_setfuncs(L,f,0)
 #endif
 
 typedef struct {
@@ -198,7 +203,13 @@ static mpack_uint32_t lmpack_objlen(lua_State *L, int *is_array)
   assert(top = lua_gettop(L));
 
   if ((type = lua_type(L, -1)) != LUA_TTABLE) {
+#if LUA_VERSION_NUM >= 502
+    len = lua_rawlen(L, -1);
+#elif LUA_VERSION_NUM == 501
     len = lua_objlen(L, -1);
+#else
+    #error You have either broken or too old Lua installation. This library requires Lua>=5.1
+#endif
     goto end;
   }
 


### PR DESCRIPTION
 - `#include`s reordered (clang-tidy)
 - luaL_reg replaced with 5.0-compat `#define` taken from 5.1's source.
   TODO: just drop it and replace "_r" to "_R" everywhere it is used.
 - a bit rewritten logic for lua_objlen and luaL_register compat-stubs.
   TODO: port to 5.3/5.4 API, and backport stubs to 5.1 (will require
   some amount of dependant code to be rewritten too).

Build/run checks was performed on:
 Compilers:
  - gcc-5.4.0
  - gcc-7.2.0
  - clang-5.0.0

 Luas:
  - lua-5.1.5
  - lua-5.2.4
  - lua-5.3.4
  - luajit-2.1.0-beta3 (git HEAD@20171101)