### PR TITLE
print the type of unserializable object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ LUA_URL ?= https://lua.org/ftp/lua-$(MPACK_LUA_VERSION).tar.gz
 LUAROCKS_URL ?= https://github.com/keplerproject/luarocks/archive/v2.2.0.tar.gz
 LUA_TARGET ?= linux
 MPACK_VERSION ?= 1.0.5
-MPACK_URL ?= https://github.com/tarruda/libmpack/archive/$(MPACK_VERSION).tar.gz
+MPACK_URL ?= https://github.com/libmpack/libmpack/archive/$(MPACK_VERSION).tar.gz
 LMPACK_VERSION != sed "/^local git_tag =/!d;s/[^']*'//;s/'\$$//;q" mpack-*.rockspec
 
 # deps location

--- a/lmpack.c
+++ b/lmpack.c
@@ -18,6 +18,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #include <lauxlib.h>
 #include <lua.h>
@@ -712,7 +713,12 @@ static void lmpack_unparse_enter(mpack_parser_t *parser, mpack_node_t *node)
       }
     /* Fallthrough */
     default:
-      luaL_error(L, "can't serialize object");
+	  {
+		/* #define FMT */
+		char errmsg[50];
+		snprintf(errmsg, 50, "can't serialize object of type %d", type);
+		luaL_error(L, errmsg);
+	  }
   }
 
 end:

--- a/mpack-1.0.8-0.rockspec
+++ b/mpack-1.0.8-0.rockspec
@@ -9,7 +9,8 @@ source = {
 
 description = {
   summary = 'Lua binding to libmpack',
-  license = 'MIT'
+  license = 'MIT',
+  homepage = 'https://github.com/libmpack/libmpack-lua'
 }
 
 build = {


### PR DESCRIPTION
Make the error 'can't serialize object' less frustating.

I've had this error too https://github.com/libmpack/libmpack/issues/30.

I haven't tested the code yet, I would like to print the key as well.

While at it, I think the rockspec should also mention libmpack as an external input (see external_dependencies in https://github.com/luarocks/luarocks/wiki/Rockspec-format#Dependency_information)