### PR TITLE
Fix luaopen_mpack to allow the module to be required multiple times

### DIFF
--- a/lmpack.c
+++ b/lmpack.c
@@ -1151,17 +1151,22 @@ int luaopen_mpack(lua_State *L)
   lua_setfield(L, -2, "__index");
   luaL_register(L, NULL, session_methods);
   /* NIL */
-  luaL_newmetatable(L, NIL_NAME);
-  lua_pushstring(L, "__tostring");
-  lua_pushcfunction(L, lmpack_nil_tostring);
-  lua_settable(L, -3);
-  /* Use a constant userdata to represent NIL */
-  (void)lua_newuserdata(L, sizeof(void *));
-  /* Assign the metatable to the userdata object */
-  luaL_getmetatable(L, NIL_NAME);
-  lua_setmetatable(L, -2);
-  /* Save NIL on the registry so we can access it easily from other functions */
-  lua_setfield(L, LUA_REGISTRYINDEX, NIL_NAME);
+  /* Check if NIL is already stored in the registry */
+  lua_getfield(L, LUA_REGISTRYINDEX, NIL_NAME);
+  /* If it isn't, create it */
+  if (lua_isnil(L, -1)) {
+    /* Use a constant userdata to represent NIL */
+    (void)lua_newuserdata(L, sizeof(void *));
+    /* Create a metatable for NIL userdata */
+    lua_createtable(L, 0, 1);
+    lua_pushstring(L, "__tostring");
+    lua_pushcfunction(L, lmpack_nil_tostring);
+    lua_settable(L, -3);
+    /* Assign the metatable to the userdata object */
+    lua_setmetatable(L, -2);
+    /* Save NIL on the registry so we can access it easily from other functions */
+    lua_setfield(L, LUA_REGISTRYINDEX, NIL_NAME);
+  }
   /* module */
   lua_newtable(L);
   luaL_register(L, NULL, mpack_functions);

--- a/test.lua
+++ b/test.lua
@@ -470,4 +470,16 @@ describe('mpack', function()
       assert.are_same("mpack.NIL", tostring(mpack.NIL))
     end)
   end)
+
+  it('should allow to be required twice', function()
+    package.loaded['mpack'] = nil
+    local ok, new_mpack_or_err = pcall(require, 'mpack')
+    assert.is_true(ok, new_mpack_or_err)
+    assert.are.equals(new_mpack_or_err.NIL, mpack.NIL)
+    assert.are.equals(
+      getmetatable(mpack.NIL),
+      getmetatable(new_mpack_or_err.NIL)
+    )
+  end)
+
 end)


### PR DESCRIPTION
The `mpack` module cannot be loaded more than once (loaded in terms of a call `luaopen_mpack` function) at the moment.

How to reproduce the error:

```lua
-- load_twice.lua
require('mpack')
package.loaded['mpack'] = nil
require('mpack')
```

```shell
$ lua load_twice.lua
lua: attempt to index a mpack.NIL value
```

Here are the details: https://stackoverflow.com/questions/62069446/lua-require-mpack-twice-in-different-files-fails/62076199


This happens because `NIL_NAME` is used for both the userdata value and its metatable: 

1. https://github.com/libmpack/libmpack-lua/blob/1.0.8/lmpack.c#L1148
2. https://github.com/libmpack/libmpack-lua/blob/1.0.8/lmpack.c#L1158

So, when the library is loaded for the first time, `luaL_newmetatable` creates a new table and stores it in the regitstry, then the userdata is stored in the registry under the same name (`lua_setfield`), and when the library in loaded again, `luaL_newmetatable` does not create a new table again but returns an existing value which is a previously stored userdata.

The is no reason to store the metatable in the registry, it is not used by the library, so I've just replaced `luaL_newmetatable` with `lua_createtable` which also creates a table but does not add it to the Lua registry.

