### PR TITLE
Fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
     packages:
       - valgrind
       - liblua5.1-0-dev
+      - libtool-bin
 
 matrix:
   include:

--- a/lmpack.c
+++ b/lmpack.c
@@ -15,6 +15,8 @@
  * compilation.
  */
 #define LUA_LIB
+/* for snprintf */
+#define _XOPEN_SOURCE 500
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This PR addresses the two issues that were causing Travis to be entirely red:

* The builds were failing because `snprintf()` wasn't declared.  Due to the strict compile settings, this needs `_XOPEN_SOURCE` to be defined to a value >= 500
* Once that issue was addressed, libtool was missing since it was moved to the libtool-bin package.

Adding the dependency on libtool-bin is somewhat of a workaround since libtool is _really_ supposed to be [configured](https://www.gnu.org/software/libtool/manual/html_node/Configuring.html#Configuring) as part of the build (particularly in the case of cross-compiling).