### PR TITLE
lmpack.c: Build on OS X

### DIFF
--- a/lmpack.c
+++ b/lmpack.c
@@ -16,7 +16,12 @@
  */
 #define LUA_LIB
 /* for snprintf */
+#ifdef __APPLE__
+// Apple uses C99 source, not XOPEN
+#define _C99_SOURCE 1
+#else
 #define _XOPEN_SOURCE 500
+#endif
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Seems the OS X requires _C99_SOURCE or similar to define snprintf.  Add that define.