### PR TITLE
Fix build & install on osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CC ?= gcc
 PKG_CONFIG ?= pkg-config
 CFLAGS ?= -ansi -O0 -g3 -Wall -Wextra -Werror -Wconversion \
 	-Wstrict-prototypes -Wno-unused-parameter -pedantic
-CFLAGS += -fPIC -DMPACK_DEBUG_REGISTRY_LEAK
+CFLAGS += -fPIC -std=c99 -DMPACK_DEBUG_REGISTRY_LEAK
 ifeq ($(MPACK_LUA_VERSION_NOPATCH),5.3)
 # Lua 5.3 has integer type, which is not 64 bits for -ansi since c89 doesn't
 # have `long long` type.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,7 @@
 LUA_TARGET=$(PLATFORM) make
 ```
 
-Where `PLATFORM` is a supported platform for lua 5.1 (freebsd, linux, macosx etc.)
-
-```bash
-# e.g. for osx
-LUA_TARGET=macosx make
-```
-
+Where `PLATFORM` is a supported Lua 5.1 platform: linux (default), freebsd, macosx, ...
 For a complete list of targets run:
 ```bash
 make; cd .deps/5.1.5/src/lua && make

--- a/README.md
+++ b/README.md
@@ -2,3 +2,22 @@
 
 [![Travis Build Status](https://travis-ci.org/libmpack/libmpack-lua.svg?branch=master)](https://travis-ci.org/libmpack/libmpack-lua)
 
+## Building
+
+```bash
+LUA_TARGET=$(PLATFORM) make
+```
+
+Where `PLATFORM` is a supported platform for lua 5.1 (freebsd, linux, macosx etc.)
+
+```bash
+# e.g. for osx
+LUA_TARGET=macosx make
+```
+
+For a complete list of targets run:
+```bash
+make; cd .deps/5.1.5/src/lua && make
+```
+
+`LUA_TARGET` will default to `linux` if not specified.

--- a/README.md
+++ b/README.md
@@ -19,5 +19,3 @@ For a complete list of targets run:
 ```bash
 make; cd .deps/5.1.5/src/lua && make
 ```
-
-`LUA_TARGET` will default to `linux` if not specified.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ LUA_TARGET=$(PLATFORM) make
 ```
 
 Where `PLATFORM` is a supported Lua 5.1 platform: linux (default), freebsd, macosx, ...
-For a complete list of targets run:
+
+For the complete list of targets run:
 ```bash
 make; cd .deps/5.1.5/src/lua && make
 ```

--- a/lmpack.c
+++ b/lmpack.c
@@ -16,7 +16,12 @@
  */
 #define LUA_LIB
 /* for snprintf */
+#ifdef __APPLE__
+// Apple uses C99 source, not XOPEN
+#define _C99_SOURCE 1
+#else
 #define _XOPEN_SOURCE 500
+#endif
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fix building on osx and add install instructions for non-linux platforms.

```bash

uname -a
# Darwin hostname 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:22 PDT 2 022; root:xnu-8020.121.3~4/RELEASE_X86_64 x86_64
```

On `master`
```bash
make
# ...

# gcc -o lua  lua.o liblua.a -lm -Wl,-E -ldl -lreadline -lhistory -lncurses
# ld: unknown option: -E
# clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This error installing lua is fixed by specifying a `LUA_TARGET` of `macosx` instead of `linux`. In general, several `LUA_TARGET`s can be specified. I've added them to `README.md`. The source of truth is `make` from lua itself, e.g.

```bash
cd .deps/5.1.5/src/lua && make
# Please do
#    make PLATFORM
# where PLATFORM is one of these:
#    aix ansi bsd freebsd generic linux macosx mingw posix solaris
# See INSTALL for complete instructions.
```

---

After building lua successfully there are still two build errors for libmpack:

```
lmpack.c:721:3: error: implicitly declaring library function 'snprintf' with ty
pe 'int (char *, unsigned long, const char *, ...)' [-Werror,-Wimplicit-functio
n-declaration]
```

and a few occurrences of:

```
./mpack-src/src/conv.h:7:9: error: 'long long' is an extension when C99 mode is
 not enabled [-Werror,-Wlong-long]
typedef long long mpack_sintmax_t;
```
The first is fixed by #30 (this PR includes @nashidau's commit) and the second is fixed by adding `-std=c99` to `CFLAGS`.

With these changes I'm able to build and install, which satisfies the dep for [neovim/lua-client](https://github.com/neovim/lua-client).
