### PR TITLE
Fix buffer overrun when giving an offset to Session:receive

### DIFF
--- a/lmpack.c
+++ b/lmpack.c
@@ -863,7 +863,9 @@ static int lmpack_session_receive(lua_State *L)
   luaL_argcheck(L, (size_t)startpos <= len, 3,
       "start position must be less than or equal to the input string length");
 
-  str += (size_t)startpos - 1;
+  size_t offset = (size_t)startpos - 1 ;
+  str += offset;
+  len -= offset;
 
   if (session->unpacker != LUA_REFNIL) {
     lmpack_geti(L, session->reg, session->unpacker);


### PR DESCRIPTION
It was not taking the offset into account when calculating the size.

A new test for split messages, which fails without the fix, was also added.

See also:
* https://github.com/neovim/neovim/pull/27348